### PR TITLE
Fix ETH wallet generation

### DIFF
--- a/01-testnet/synergy-wallet/synergy-wallet/src/utils/umaAddresses.js
+++ b/01-testnet/synergy-wallet/synergy-wallet/src/utils/umaAddresses.js
@@ -3,6 +3,7 @@
 import { mnemonicToSeedSync } from '@scure/bip39';
 import { HDKey } from '@scure/bip32';
 import { publicToAddress, toChecksumAddress } from "ethereumjs-util";
+import { Buffer } from 'buffer';
 import { derivePath as solDerivePath } from "ed25519-hd-key";
 import { Keypair } from "@solana/web3.js";
 
@@ -43,7 +44,7 @@ export function generateETHWalletFromMnemonic(mnemonic, path = "m/44'/60'/0'/0/0
   if (pubkey[0] === 0x04 && pubkey.length === 65) {
     pubkey = pubkey.slice(1);
   }
-  const ethAddressBuffer = publicToAddress(pubkey, true); // true = ethereum
+  const ethAddressBuffer = publicToAddress(Buffer.from(pubkey), true); // true = ethereum
   const address = toChecksumAddress("0x" + ethAddressBuffer.toString("hex"));
 
   return {


### PR DESCRIPTION
## Summary
- fix ethereum wallet derivation by converting Uint8Array to `Buffer`

## Testing
- `npm test --silent`
- `node - <<'NODE'
const {generateETHWalletFromMnemonic} = require('./src/utils/umaAddresses.js');
console.log(generateETHWalletFromMnemonic('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6877daec33f883279ee922427af803e7